### PR TITLE
add write permission to the job

### DIFF
--- a/.github/workflows/hello-to-new-contributions.yml
+++ b/.github/workflows/hello-to-new-contributions.yml
@@ -4,6 +4,7 @@ on: [pull_request, issues]
 jobs:
   build:
     name: Hello new contributor
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/first-interaction@v1


### PR DESCRIPTION
Trying to get around the workflow's error message by giving the job explicit `write` permissions. 